### PR TITLE
docs: add Blaze to list of projects

### DIFF
--- a/index.md
+++ b/index.md
@@ -169,6 +169,7 @@ The first draft of this specification has been written in collaboration with som
 * [standard-version](https://github.com/conventional-changelog/standard-version): Automatic versioning and CHANGELOG management, using GitHub's new squash button and the recommended Conventional Commits workflow.
 * [uPortal-home](https://github.com/UW-Madison-DoIT/angularjs-portal) and [uPortal-application-framework](https://github.com/UW-Madison-DoIT/uw-frame): Optional supplemental user interface enhancing [Apereo uPortal](https://www.apereo.org/projects/uportal).
 * [massive.js](https://github.com/dmfay/massive-js): A data access library for Node and PostgreSQL.
+* [Blaze UI](https://github.com/BlazeUI/blaze): Framework-free open source modular toolkit.
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 


### PR DESCRIPTION
Blaze uses commitlint to ensure conventional commits are being written and it's really helped with automatically creating our change logs per package i.e. it now has some change logs!